### PR TITLE
fix: Arreglo en test de voting

### DIFF
--- a/decide/store/migrations/0001_initial.py
+++ b/decide/store/migrations/0001_initial.py
@@ -17,6 +17,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('voting_id', models.PositiveIntegerField()),
                 ('voter_id', models.PositiveIntegerField()),
+                ('question_id', models.PositiveIntegerField()),
                 ('a', models.PositiveIntegerField()),
                 ('b', models.PositiveIntegerField()),
             ],

--- a/decide/voting/migrations/0001_initial.py
+++ b/decide/voting/migrations/0001_initial.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 ('end_date', models.DateTimeField(blank=True, null=True)),
                 ('auths', models.ManyToManyField(related_name='votings', to='mixnet.Auth')),
                 ('pub_key', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='voting', to='mixnet.Key')),
-                ('question', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='voting', to='voting.Question')),
+                ('question', models.ManyToManyField(related_name='voting', to='voting.Question')),
             ],
         ),
     ]


### PR DESCRIPTION
Se ha arreglado problemas generados por el incremento de permitir mas de una pregunta en una voting en los archivos 0001_initial tanto en voting como en store, actualizando el question_id en el modelo de store y cambiando la relación entre voting y question que seguia como ForeingKey en vez de ManyToMany. Se han arreglado los métodos auxiliares para los test de voting y se ha contemplado la situación con el test de api y el test_complete_voting. Issue#34