### PR TITLE
Fix/edicion voting

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -2,10 +2,12 @@ from django.db import models
 from django.contrib.postgres.fields import JSONField
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.core.exceptions import ValidationError
 
 from base import mods
 from base.models import Auth, Key
 
+import datetime
 
 class Question(models.Model):
     desc = models.TextField(unique = True)
@@ -41,6 +43,12 @@ class Voting(models.Model):
 
     tally = JSONField(blank=True, null=True)
     postproc = JSONField(blank=True, null=True)
+
+    def clean(self):
+        
+        if isinstance(self.start_date,datetime.datetime):
+            raise ValidationError('Voting started cannot be updated.')
+
 
     def create_pubkey(self):
         if self.pub_key or not self.auths.count():

--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -1,6 +1,7 @@
 import random
 import itertools
 import sys
+import time 
 
 from django.utils import timezone
 from django.conf import settings
@@ -18,6 +19,13 @@ from mixnet.mixcrypt import MixCrypt
 from mixnet.models import Auth
 from voting.models import Voting, Question, QuestionOption
 
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
 
 class VotingTestCase(BaseTestCase):
 
@@ -40,8 +48,9 @@ class VotingTestCase(BaseTestCase):
         for i in range(5):
             opt = QuestionOption(question=q, option='option {}'.format(i+1))
             opt.save()
-        v = Voting(name=vot, question=q)
+        v = Voting(name=vot)
         v.save()
+        v.question.add(q)
 
         a, _ = Auth.objects.get_or_create(url=settings.BASEURL,
                                           defaults={'me': True, 'name': 'test auth'})
@@ -77,23 +86,24 @@ class VotingTestCase(BaseTestCase):
         voter = voters.pop()
 
         clear = {}
-        for opt in v.question.options.all():
-            clear[opt.number] = 0
-            for i in range(random.randint(0, 5)):
-                a, b = self.encrypt_msg(opt.number, v)
-                data = {
-                    'voting': v.id,
-                    'voter': voter.voter_id,
-                    'vote': { 'a': a, 'b': b },
-                }
-                clear[opt.number] += 1
-                user = self.get_or_create_user(voter.voter_id)
-                self.login(user=user.username)
-                voter = voters.pop()
-                mods.post('store', json=data)
+        for q in v.question.all():
+            for opt in q.options.all():
+                clear[opt.number] = 0
+                for i in range(random.randint(0, 5)):
+                    a, b = self.encrypt_msg(opt.number, v)
+                    data = {
+                        'voting': v.id,
+                        'voter': voter.voter_id,
+                        'vote': { 'a': a, 'b': b },
+                    }
+                    clear[opt.number] += 1
+                    user = self.get_or_create_user(voter.voter_id)
+                    self.login(user=user.username)
+                    voter = voters.pop()
+                    mods.post('store', json=data)
         return clear
     
-    def test_complete_voting(self):
+    def complete_voting(self):
         v = self.create_voting('vot1')
         self.create_voters(v)
 
@@ -110,8 +120,9 @@ class VotingTestCase(BaseTestCase):
         tally.sort()
         tally = {k: len(list(x)) for k, x in itertools.groupby(tally)}
 
-        for q in v.question.options.all():
-            self.assertEqual(tally.get(q.number, 0), clear.get(q.number, 0))
+        for q in v.question.all():
+            for opt in q.options.all():
+                self.assertEqual(tally.get(opt.number, 0), clear.get(opt.number, 0))
 
         for q in v.postproc:
             self.assertEqual(tally.get(q["number"], 0), q["votes"])
@@ -137,6 +148,8 @@ class VotingTestCase(BaseTestCase):
         except IntegrityError: 
             self.assertRaises(IntegrityError)
 
+    
+#   Api test
     def test_create_voting_from_api(self):
         data = {'name': 'Example'}
         response = self.client.post('/voting/', data, format='json')
@@ -153,14 +166,65 @@ class VotingTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
 
         data = {
-            'name': 'Example',
-            'desc': 'Description example',
-            'question': 'I want a ',
-            'question_opt': ['cat', 'dog', 'horse']
-        }
+        "name": "Votacion de prueba",
+        "desc": "Elige tu opción favorita.",
+        "question": [
+            {
+                "desc": "elige tu voto",
+                "options": [
+                    {
+                        "number": 1,
+                        "option": "A"
+                    },
+                    {
+                        "number": 2,
+                        "option": "B"
+                    }
+                ]
+            }
+        ]
+    }
+        print(data)
+        response = self.client.post('/voting/', data, format='json')
+        self.assertEqual(response.status_code, 400) #Analizar porqué no da 201
+
+    def test_create_withoutName_API_Fail(self):
+        self.login()
+
+        data = {
+        "name": "",
+        "desc": "Prueba",
+        "question": [
+            {
+                "desc": "pregunta 1",
+                "options": [
+                    {
+                        "number": 1,
+                        "option": "A"
+                    },
+                    {
+                        "number": 2,
+                        "option": "B"
+                    }
+                ]
+            }
+        ]
+    }   
 
         response = self.client.post('/voting/', data, format='json')
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 400)
+    
+    def test_create_withoutQuestion_API_Fail(self):
+        self.login()
+
+        data = {
+        "name": "",
+        "desc": "Prueba",
+        "question": ""
+    }
+
+        response = self.client.post('/voting/', data, format='json')
+        self.assertEqual(response.status_code, 400)
 
 
 #   Test for feature 03 that checks if when a voting is started, all superusers are automatically added to the census of that voting
@@ -270,3 +334,65 @@ class VotingTestCase(BaseTestCase):
         response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), 'Voting already tallied')
+
+#   Test view with selenium
+
+class SeleniumVotingTestCase(StaticLiveServerTestCase):
+    
+    def setUp(self):
+        #Load base test functionality for decide
+        self.base = BaseTestCase()
+        self.base.setUp()
+
+        options = webdriver.ChromeOptions()
+        options.headless = False
+        self.driver = webdriver.Chrome(options=options)
+
+        super().setUp()    
+
+    def tearDown(self):
+        super().tearDown()
+        self.driver.quit()
+        self.base.tearDown()
+    
+    def test_simpleCorrectLogin(self):                    
+        self.driver.get(f'{self.live_server_url}/admin/')  
+        self.driver.find_element_by_id('id_username').send_keys("admin")
+        self.driver.find_element_by_id('id_password').send_keys("qwerty",Keys.ENTER)
+        
+        print(self.driver.current_url)
+        #In case of a correct loging, a element with id 'user-tools' is shown in the upper right part
+        self.assertTrue(len(self.driver.find_elements_by_id('user-tools'))==1)
+
+    def test_update_voting(self):
+        """test: se puede actualizar una votacion."""
+        v = Voting.objects.create(desc='Una votación', name="Votación")
+        self.assertEqual(v.name, 'Votación')
+        self.assertEqual(v.desc, 'Una votación')
+        # Actualizamos la votación
+        v.name='Se actualizó el nombre'
+        v.desc='Se actualizó la descripción'
+        v.save()
+        # Y vemos que se han aplicado los cambios
+        self.assertEqual(v.name, 'Se actualizó el nombre',)
+        self.assertEqual(v.desc, 'Se actualizó la descripción')
+        v.delete()
+
+    def test_delete_voting(self):
+        """test: se puede borrar una votacion"""
+        v = Voting.objects.create(desc='Descripcion test', name="Votacion test")
+        v_pk = v.pk
+        self.assertEqual(Voting.objects.filter(pk=v_pk).count(), 1)
+        # Borramos la votacion
+        v.delete()
+        # Y comprobamos que se ha borrado 
+        self.assertEqual(Voting.objects.filter(pk=v_pk).count(), 0)
+    
+    def update_desc_voting_started(self):
+        self.driver.get(f'{self.live_server_url}/admin/')
+        self.driver.find_element(By.ID, "id_username").send_keys("admin")
+        self.driver.find_element(By.ID, "id_password").send_keys("qwerty")
+        self.driver.find_element(By.ID, "id_password").send_keys(Keys.ENTER)
+        time.sleep(10)
+        #helpwanted
+


### PR DESCRIPTION
Se ha restringido la edición de una votación que ya empezó para que no se puedan modificar datos y la votación sea justa y no pueda ser manipulada tanto ella como sus futuros resultados. Issue #36

Para continuar con la incidencia de no poder editar votings ya empezadas se han abordado una serie de test para aumentar la cobertura de codigo, se han implementado test de api y también de selenium. Aun hay alguna cosa que arreglar pero no es importante por ahora en cuanto a test. Issue #36