### PR TITLE
fix: Arreglo configuración selenium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ django-rest-swagger==2.2.0
 coverage==4.5.2
 django-nose==1.4.6
 jsonnet==0.12.1
+selenium


### PR DESCRIPTION
Tras añadir test nuevos y entre ellos, test de selenium, se ha de añadir en los requirements del proyecto selenium para poder utilizarse. Para ello se añade en esta fix en la rama develop. Issue #39