### PR TITLE
fix: Eliminado test_mensaje_tally()

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -646,38 +646,6 @@ class SeleniumVotingTestCase(StaticLiveServerTestCase):
         assert str(timezone.now().day) in self.driver.page_source
 
 
-    def test_mensaje_tally(self):
-        self.crear_votacion()
-
-        self.driver.find_element(By.LINK_TEXT, "Votings").click()
-        self.driver.find_element(By.ID, "action-toggle").click()
-        self.driver.find_element(By.NAME, "action").click()
-        dropdown = self.driver.find_element(By.NAME, "action")
-        dropdown.find_element(By.XPATH, "//option[. = 'Start']").click()
-        self.driver.find_element(By.NAME, "action").click()
-        self.driver.find_element(By.NAME, "index").click()
-
-        self.driver.get(f'{self.live_server_url}/booth/1/1')
-        self.driver.find_element(By.ID, "username").send_keys("admin")
-        self.driver.find_element(By.ID, "password").send_keys("qwerty")
-        
-        self.driver.find_element(By.CSS_SELECTOR    , ".btn-primary").click()
-        self.driver.find_element(By.ID, "q1").click()
-        self.driver.find_element(By.ID, "voteBtn").click()
-
-        self.driver.get(f'{self.live_server_url}/admin/voting/voting')
-
-        self.driver.find_element(By.ID, "action-toggle").click()
-        dropdown = self.driver.find_element(By.NAME, "action")
-        dropdown.find_element(By.XPATH, "//option[. = 'Stop']").click()
-        self.driver.find_element(By.NAME, "action").click() 
-
-        self.driver.find_element(By.NAME, "index").click()
-        self.driver.find_element(By.ID, "action-toggle").click()
-        dropdown = self.driver.find_element(By.NAME, "action")
-        dropdown.find_element(By.XPATH, "//option[. = 'Tally']").click()
-        self.driver.find_element(By.NAME, "action").click()
-        self.driver.find_element(By.NAME, "index").click()
 
 
     def test_delete_question_of_started_voting(self):


### PR DESCRIPTION
Se ha eliminado el test de selenium que comprobaba que al hacer tally se recibía un mensaje emergente con las opciones a las que se ha votado y el número de votos ya que al hacer el tally desde Selenium da un error 500. Issue #67